### PR TITLE
chore: Suppress npm warning.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -45,7 +45,7 @@ program.parse(process.argv);
 	Output.info('Installing Superfast')
 
 	try {
-		await execa('npx', ['-y', 'superfastcms', 'init', `-p ${directory}`], {stdio: 'inherit'});
+		await execa('npx', ['--silent', '-y', 'superfastcms', 'init', `-p ${directory}`], {stdio: 'inherit'});
 	} catch (err) {
 		Output.error(err.message || 'Unknown error')
 		process.exit(1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-superfast-app",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Create Superfast apps in one command",
   "type": "module",
   "exports": "./index.js",


### PR DESCRIPTION
## 何をしたか
- `superfastcms init` のコマンドに `--silent` オプションを追加
  - 推移的依存関係にあるライブラリの warning を出力しない